### PR TITLE
A few fixes and enhancements to header and data styling

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,7 +36,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   List rows = [
     {
-      "name": 'James Joe',
+      "name": 'James LongName Joe',
       "date": '23/09/2020',
       "month": 'June',
       "status": 'completed'
@@ -110,6 +110,7 @@ class _MyHomePageState extends State<MyHomePage> {
         columns: cols,
         rows: rows,
         zebraStripe: true,
+        stripeColor1: Colors.blue[50],
         stripeColor2: Colors.grey[200],
         onRowSaved: (value) {
           print(value);
@@ -118,9 +119,17 @@ class _MyHomePageState extends State<MyHomePage> {
           print(value);
         },
         borderColor: Colors.blueGrey,
+        tdStyle: TextStyle( fontWeight: FontWeight.bold ),
+        trHeight: 80,
+        thStyle: TextStyle( fontSize: 15, fontWeight: FontWeight.bold ),
+        thAlignment: TextAlign.center,
+        thVertAlignment: CrossAxisAlignment.end,
+        thPaddingBottom: 3,
         showSaveIcon: true,
         saveIconColor: Colors.black,
         showCreateButton: true,
+        tdAlignment: TextAlign.left,
+        tdEditableMaxLines: 100,  // don't limit and allow data to wrap
         tdPaddingTop: 0,
         tdPaddingBottom: 14,
         tdPaddingLeft: 10,

--- a/lib/editable.dart
+++ b/lib/editable.dart
@@ -172,7 +172,7 @@ class Editable extends StatefulWidget {
   /// Style the table data
   final TextStyle tdStyle;
 
-  /// Max lines allowed in editable text, default: 1 (longer data will not wrap and be hidden)
+  /// Max lines allowed in editable text, default: 1 (longer data will not wrap and be hidden), setting to 100 will allow wrapping and not increase row size
   final int tdEditableMaxLines;
 
   /// Table header cell padding left

--- a/lib/editable.dart
+++ b/lib/editable.dart
@@ -46,42 +46,45 @@ class Editable extends StatefulWidget {
   /// ```
   Editable(
       {Key key,
-      this.columns,
-      this.rows,
-      this.columnRatio = 0.20,
-      this.onSubmitted,
-      this.onRowSaved,
-      this.columnCount = 0,
-      this.rowCount = 0,
-      this.borderColor = Colors.grey,
-      this.tdPaddingLeft = 8.0,
-      this.tdPaddingTop = 8.0,
-      this.tdPaddingRight = 8.0,
-      this.tdPaddingBottom = 12.0,
-      this.thPaddingLeft = 8.0,
-      this.thPaddingTop = 0.0,
-      this.thPaddingRight = 8.0,
-      this.thPaddingBottom = 0.0,
-      this.trHeight = 50.0,
-      this.borderWidth = 0.5,
-      this.thWeight = FontWeight.w600,
-      this.thSize = 18,
-      this.showSaveIcon = false,
-      this.saveIcon = Icons.save,
-      this.saveIconColor = Colors.black12,
-      this.saveIconSize = 18,
-      this.tdAlignment = TextAlign.start,
-      this.tdStyle,
-      this.showCreateButton = false,
-      this.createButtonAlign = CrossAxisAlignment.start,
-      this.createButtonIcon,
-      this.createButtonColor,
-      this.createButtonShape,
-      this.createButtonLabel,
-      this.stripeColor1 = Colors.white,
-      this.stripeColor2 = Colors.black12,
-      this.zebraStripe = false,
-      this.focusedBorder})
+        this.columns,
+        this.rows,
+        this.columnRatio = 0.20,
+        this.onSubmitted,
+        this.onRowSaved,
+        this.columnCount = 0,
+        this.rowCount = 0,
+        this.borderColor = Colors.grey,
+        this.tdPaddingLeft = 8.0,
+        this.tdPaddingTop = 8.0,
+        this.tdPaddingRight = 8.0,
+        this.tdPaddingBottom = 12.0,
+        this.thPaddingLeft = 8.0,
+        this.thPaddingTop = 0.0,
+        this.thPaddingRight = 8.0,
+        this.thPaddingBottom = 0.0,
+        this.trHeight = 50.0,
+        this.borderWidth = 0.5,
+        this.thWeight = FontWeight.w600,
+        this.thSize = 18,
+        this.showSaveIcon = false,
+        this.saveIcon = Icons.save,
+        this.saveIconColor = Colors.black12,
+        this.saveIconSize = 18,
+        this.tdAlignment = TextAlign.start,
+        this.tdStyle,
+        this.thAlignment = TextAlign.start,
+        this.thStyle,
+        this.thVertAlignment = CrossAxisAlignment.center,
+        this.showCreateButton = false,
+        this.createButtonAlign = CrossAxisAlignment.start,
+        this.createButtonIcon,
+        this.createButtonColor,
+        this.createButtonShape,
+        this.createButtonLabel,
+        this.stripeColor1 = Colors.white,
+        this.stripeColor2 = Colors.black12,
+        this.zebraStripe = false,
+        this.focusedBorder})
       : super(key: key);
 
   /// A data set to create headers
@@ -180,15 +183,24 @@ class Editable extends StatefulWidget {
   /// Table header cell padding bottom
   final double thPaddingBottom;
 
+  /// Aligns the table header
+  final TextAlign thAlignment;
+
+  /// Style the table header - use for more control of header style, using this OVERRIDES the thWeight and thSize parameters and those will be ignored.
+  final TextStyle thStyle;
+
+  /// Table headers fontweight (use thStyle for more control of header style)
+  final FontWeight thWeight;
+
+  /// Table header label vertical alignment
+  final CrossAxisAlignment thVertAlignment;
+
+  /// Table headers fontSize  (use thStyle for more control of header style)
+  final double thSize;
+
   /// Table Row Height
   /// cannot be less than 40.0
   final double trHeight;
-
-  /// Table headers fontweight
-  final FontWeight thWeight;
-
-  /// Table headers fontSize
-  final double thSize;
 
   /// Toogles the save button,
   /// if [true] displays an icon to save rows,
@@ -281,7 +293,7 @@ class EditableState extends State<Editable> {
     /// initial Setup of columns and row, sets count of column and row
     rowCount = rows == null || rows.isEmpty ? widget.rowCount : rows.length;
     columnCount =
-        columns == null || columns.isEmpty ? columnCount : columns.length;
+    columns == null || columns.isEmpty ? columnCount : columns.length;
     columns = columns ?? columnBlueprint(columnCount, columns);
     rows = rows ?? rowBlueprint(rowCount, columns, rows);
 
@@ -301,7 +313,7 @@ class EditableState extends State<Editable> {
             ),
             onPressed: () {
               int rowIndex = editedRows.indexWhere(
-                  (element) => element['row'] == index ? true : false);
+                      (element) => element['row'] == index ? true : false);
               if (rowIndex != -1) {
                 widget.onRowSaved(editedRows[rowIndex]);
               } else {
@@ -318,19 +330,21 @@ class EditableState extends State<Editable> {
       return List<Widget>.generate(columnCount + 1, (index) {
         return columnCount + 1 == (index + 1)
             ? iconColumn(widget.showSaveIcon, widget.thPaddingTop,
-                widget.thPaddingBottom)
+            widget.thPaddingBottom)
             : THeader(
-                widthRatio: columns[index]['widthFactor'] != null
-                    ? columns[index]['widthFactor'].toDouble()
-                    : widget.columnRatio,
-                thPaddingLeft: widget.thPaddingLeft,
-                thPaddingTop: widget.thPaddingTop,
-                thPaddingBottom: widget.thPaddingBottom,
-                thPaddingRight: widget.thPaddingRight,
-                headers: columns,
-                thWeight: widget.thWeight,
-                thSize: widget.thSize,
-                index: index);
+            widthRatio: columns[index]['widthFactor'] != null
+                ? columns[index]['widthFactor'].toDouble()
+                : widget.columnRatio,
+            thAlignment: widget.thAlignment,
+            thStyle: widget.thStyle,
+            thPaddingLeft: widget.thPaddingLeft,
+            thPaddingTop: widget.thPaddingTop,
+            thPaddingBottom: widget.thPaddingBottom,
+            thPaddingRight: widget.thPaddingRight,
+            headers: columns,
+            thWeight: widget.thWeight,
+            thSize: widget.thSize,
+            index: index);
       });
     }
 
@@ -353,42 +367,42 @@ class EditableState extends State<Editable> {
             return columnCount + 1 == (rowIndex + 1)
                 ? _saveIcon(index)
                 : RowBuilder(
-                    index: index,
-                    col: ckeys[rowIndex],
-                    trHeight: widget.trHeight,
-                    borderColor: widget.borderColor,
-                    borderWidth: widget.borderWidth,
-                    cellData: list[ckeys[rowIndex]],
-                    tdPaddingLeft: widget.tdPaddingLeft,
-                    tdPaddingTop: widget.tdPaddingTop,
-                    tdPaddingBottom: widget.tdPaddingBottom,
-                    tdPaddingRight: widget.tdPaddingRight,
-                    tdAlignment: widget.tdAlignment,
-                    tdStyle: widget.tdStyle,
-                    onSubmitted: widget.onSubmitted,
-                    widthRatio: cwidths[rowIndex].toDouble(),
-                    isEditable: ceditable[rowIndex],
-                    zebraStripe: widget.zebraStripe,
-                    focusedBorder: widget.focusedBorder,
-                    stripeColor1: widget.stripeColor1,
-                    stripeColor2: widget.stripeColor2,
-                    onChanged: (value) {
-                      ///checks if row has been edited previously
-                      var result = editedRows.indexWhere((element) {
-                        return element['row'] != index ? false : true;
-                      });
+              index: index,
+              col: ckeys[rowIndex],
+              trHeight: widget.trHeight,
+              borderColor: widget.borderColor,
+              borderWidth: widget.borderWidth,
+              cellData: list[ckeys[rowIndex]],
+              tdPaddingLeft: widget.tdPaddingLeft,
+              tdPaddingTop: widget.tdPaddingTop,
+              tdPaddingBottom: widget.tdPaddingBottom,
+              tdPaddingRight: widget.tdPaddingRight,
+              tdAlignment: widget.tdAlignment,
+              tdStyle: widget.tdStyle,
+              onSubmitted: widget.onSubmitted,
+              widthRatio: cwidths[rowIndex].toDouble(),
+              isEditable: ceditable[rowIndex],
+              zebraStripe: widget.zebraStripe,
+              focusedBorder: widget.focusedBorder,
+              stripeColor1: widget.stripeColor1,
+              stripeColor2: widget.stripeColor2,
+              onChanged: (value) {
+                ///checks if row has been edited previously
+                var result = editedRows.indexWhere((element) {
+                  return element['row'] != index ? false : true;
+                });
 
-                      ///adds a new edited data to a temporary holder
-                      if (result != -1) {
-                        editedRows[result][ckeys[rowIndex]] = value;
-                      } else {
-                        var temp = {};
-                        temp['row'] = index;
-                        temp[ckeys[rowIndex]] = value;
-                        editedRows.add(temp);
-                      }
-                    },
-                  );
+                ///adds a new edited data to a temporary holder
+                if (result != -1) {
+                  editedRows[result][ckeys[rowIndex]] = value;
+                } else {
+                  var temp = {};
+                  temp['row'] = index;
+                  temp[ckeys[rowIndex]] = value;
+                  editedRows.add(temp);
+                }
+              },
+            );
           }),
         );
       });
@@ -401,7 +415,7 @@ class EditableState extends State<Editable> {
         child: SingleChildScrollView(
           scrollDirection: Axis.horizontal,
           child:
-              Column(crossAxisAlignment: widget.createButtonAlign, children: [
+          Column(crossAxisAlignment: widget.createButtonAlign, children: [
             //Table Header
             createButton(),
             Container(
@@ -412,6 +426,7 @@ class EditableState extends State<Editable> {
                           color: widget.borderColor,
                           width: widget.borderWidth))),
               child: Row(
+                  crossAxisAlignment: widget.thVertAlignment,
                   mainAxisSize: MainAxisSize.min, children: _tableHeaders()),
             ),
 

--- a/lib/editable.dart
+++ b/lib/editable.dart
@@ -72,6 +72,7 @@ class Editable extends StatefulWidget {
         this.saveIconSize = 18,
         this.tdAlignment = TextAlign.start,
         this.tdStyle,
+        this.tdEditableMaxLines = 1,
         this.thAlignment = TextAlign.start,
         this.thStyle,
         this.thVertAlignment = CrossAxisAlignment.center,
@@ -170,6 +171,9 @@ class Editable extends StatefulWidget {
 
   /// Style the table data
   final TextStyle tdStyle;
+
+  /// Max lines allowed in editable text, default: 1 (longer data will not wrap and be hidden)
+  final int tdEditableMaxLines;
 
   /// Table header cell padding left
   final double thPaddingLeft;
@@ -379,6 +383,7 @@ class EditableState extends State<Editable> {
               tdPaddingRight: widget.tdPaddingRight,
               tdAlignment: widget.tdAlignment,
               tdStyle: widget.tdStyle,
+              tdEditableMaxLines: widget.tdEditableMaxLines,
               onSubmitted: widget.onSubmitted,
               widthRatio: cwidths[rowIndex].toDouble(),
               isEditable: ceditable[rowIndex],

--- a/lib/editable.dart
+++ b/lib/editable.dart
@@ -46,46 +46,46 @@ class Editable extends StatefulWidget {
   /// ```
   Editable(
       {Key key,
-        this.columns,
-        this.rows,
-        this.columnRatio = 0.20,
-        this.onSubmitted,
-        this.onRowSaved,
-        this.columnCount = 0,
-        this.rowCount = 0,
-        this.borderColor = Colors.grey,
-        this.tdPaddingLeft = 8.0,
-        this.tdPaddingTop = 8.0,
-        this.tdPaddingRight = 8.0,
-        this.tdPaddingBottom = 12.0,
-        this.thPaddingLeft = 8.0,
-        this.thPaddingTop = 0.0,
-        this.thPaddingRight = 8.0,
-        this.thPaddingBottom = 0.0,
-        this.trHeight = 50.0,
-        this.borderWidth = 0.5,
-        this.thWeight = FontWeight.w600,
-        this.thSize = 18,
-        this.showSaveIcon = false,
-        this.saveIcon = Icons.save,
-        this.saveIconColor = Colors.black12,
-        this.saveIconSize = 18,
-        this.tdAlignment = TextAlign.start,
-        this.tdStyle,
-        this.tdEditableMaxLines = 1,
-        this.thAlignment = TextAlign.start,
-        this.thStyle,
-        this.thVertAlignment = CrossAxisAlignment.center,
-        this.showCreateButton = false,
-        this.createButtonAlign = CrossAxisAlignment.start,
-        this.createButtonIcon,
-        this.createButtonColor,
-        this.createButtonShape,
-        this.createButtonLabel,
-        this.stripeColor1 = Colors.white,
-        this.stripeColor2 = Colors.black12,
-        this.zebraStripe = false,
-        this.focusedBorder})
+      this.columns,
+      this.rows,
+      this.columnRatio = 0.20,
+      this.onSubmitted,
+      this.onRowSaved,
+      this.columnCount = 0,
+      this.rowCount = 0,
+      this.borderColor = Colors.grey,
+      this.tdPaddingLeft = 8.0,
+      this.tdPaddingTop = 8.0,
+      this.tdPaddingRight = 8.0,
+      this.tdPaddingBottom = 12.0,
+      this.thPaddingLeft = 8.0,
+      this.thPaddingTop = 0.0,
+      this.thPaddingRight = 8.0,
+      this.thPaddingBottom = 0.0,
+      this.trHeight = 50.0,
+      this.borderWidth = 0.5,
+      this.thWeight = FontWeight.w600,
+      this.thSize = 18,
+      this.showSaveIcon = false,
+      this.saveIcon = Icons.save,
+      this.saveIconColor = Colors.black12,
+      this.saveIconSize = 18,
+      this.tdAlignment = TextAlign.start,
+      this.tdStyle,
+      this.tdEditableMaxLines = 1,
+      this.thAlignment = TextAlign.start,
+      this.thStyle,
+      this.thVertAlignment = CrossAxisAlignment.center,
+      this.showCreateButton = false,
+      this.createButtonAlign = CrossAxisAlignment.start,
+      this.createButtonIcon,
+      this.createButtonColor,
+      this.createButtonShape,
+      this.createButtonLabel,
+      this.stripeColor1 = Colors.white,
+      this.stripeColor2 = Colors.black12,
+      this.zebraStripe = false,
+      this.focusedBorder})
       : super(key: key);
 
   /// A data set to create headers
@@ -297,7 +297,7 @@ class EditableState extends State<Editable> {
     /// initial Setup of columns and row, sets count of column and row
     rowCount = rows == null || rows.isEmpty ? widget.rowCount : rows.length;
     columnCount =
-    columns == null || columns.isEmpty ? columnCount : columns.length;
+        columns == null || columns.isEmpty ? columnCount : columns.length;
     columns = columns ?? columnBlueprint(columnCount, columns);
     rows = rows ?? rowBlueprint(rowCount, columns, rows);
 
@@ -317,7 +317,7 @@ class EditableState extends State<Editable> {
             ),
             onPressed: () {
               int rowIndex = editedRows.indexWhere(
-                      (element) => element['row'] == index ? true : false);
+                  (element) => element['row'] == index ? true : false);
               if (rowIndex != -1) {
                 widget.onRowSaved(editedRows[rowIndex]);
               } else {
@@ -334,21 +334,21 @@ class EditableState extends State<Editable> {
       return List<Widget>.generate(columnCount + 1, (index) {
         return columnCount + 1 == (index + 1)
             ? iconColumn(widget.showSaveIcon, widget.thPaddingTop,
-            widget.thPaddingBottom)
+                widget.thPaddingBottom)
             : THeader(
-            widthRatio: columns[index]['widthFactor'] != null
-                ? columns[index]['widthFactor'].toDouble()
-                : widget.columnRatio,
-            thAlignment: widget.thAlignment,
-            thStyle: widget.thStyle,
-            thPaddingLeft: widget.thPaddingLeft,
-            thPaddingTop: widget.thPaddingTop,
-            thPaddingBottom: widget.thPaddingBottom,
-            thPaddingRight: widget.thPaddingRight,
-            headers: columns,
-            thWeight: widget.thWeight,
-            thSize: widget.thSize,
-            index: index);
+                widthRatio: columns[index]['widthFactor'] != null
+                    ? columns[index]['widthFactor'].toDouble()
+                    : widget.columnRatio,
+                thAlignment: widget.thAlignment,
+                thStyle: widget.thStyle,
+                thPaddingLeft: widget.thPaddingLeft,
+                thPaddingTop: widget.thPaddingTop,
+                thPaddingBottom: widget.thPaddingBottom,
+                thPaddingRight: widget.thPaddingRight,
+                headers: columns,
+                thWeight: widget.thWeight,
+                thSize: widget.thSize,
+                index: index);
       });
     }
 
@@ -371,43 +371,43 @@ class EditableState extends State<Editable> {
             return columnCount + 1 == (rowIndex + 1)
                 ? _saveIcon(index)
                 : RowBuilder(
-              index: index,
-              col: ckeys[rowIndex],
-              trHeight: widget.trHeight,
-              borderColor: widget.borderColor,
-              borderWidth: widget.borderWidth,
-              cellData: list[ckeys[rowIndex]],
-              tdPaddingLeft: widget.tdPaddingLeft,
-              tdPaddingTop: widget.tdPaddingTop,
-              tdPaddingBottom: widget.tdPaddingBottom,
-              tdPaddingRight: widget.tdPaddingRight,
-              tdAlignment: widget.tdAlignment,
-              tdStyle: widget.tdStyle,
-              tdEditableMaxLines: widget.tdEditableMaxLines,
-              onSubmitted: widget.onSubmitted,
-              widthRatio: cwidths[rowIndex].toDouble(),
-              isEditable: ceditable[rowIndex],
-              zebraStripe: widget.zebraStripe,
-              focusedBorder: widget.focusedBorder,
-              stripeColor1: widget.stripeColor1,
-              stripeColor2: widget.stripeColor2,
-              onChanged: (value) {
-                ///checks if row has been edited previously
-                var result = editedRows.indexWhere((element) {
-                  return element['row'] != index ? false : true;
-                });
+                    index: index,
+                    col: ckeys[rowIndex],
+                    trHeight: widget.trHeight,
+                    borderColor: widget.borderColor,
+                    borderWidth: widget.borderWidth,
+                    cellData: list[ckeys[rowIndex]],
+                    tdPaddingLeft: widget.tdPaddingLeft,
+                    tdPaddingTop: widget.tdPaddingTop,
+                    tdPaddingBottom: widget.tdPaddingBottom,
+                    tdPaddingRight: widget.tdPaddingRight,
+                    tdAlignment: widget.tdAlignment,
+                    tdStyle: widget.tdStyle,
+                    tdEditableMaxLines: widget.tdEditableMaxLines,
+                    onSubmitted: widget.onSubmitted,
+                    widthRatio: cwidths[rowIndex].toDouble(),
+                    isEditable: ceditable[rowIndex],
+                    zebraStripe: widget.zebraStripe,
+                    focusedBorder: widget.focusedBorder,
+                    stripeColor1: widget.stripeColor1,
+                    stripeColor2: widget.stripeColor2,
+                    onChanged: (value) {
+                      ///checks if row has been edited previously
+                      var result = editedRows.indexWhere((element) {
+                        return element['row'] != index ? false : true;
+                      });
 
-                ///adds a new edited data to a temporary holder
-                if (result != -1) {
-                  editedRows[result][ckeys[rowIndex]] = value;
-                } else {
-                  var temp = {};
-                  temp['row'] = index;
-                  temp[ckeys[rowIndex]] = value;
-                  editedRows.add(temp);
-                }
-              },
-            );
+                      ///adds a new edited data to a temporary holder
+                      if (result != -1) {
+                        editedRows[result][ckeys[rowIndex]] = value;
+                      } else {
+                        var temp = {};
+                        temp['row'] = index;
+                        temp[ckeys[rowIndex]] = value;
+                        editedRows.add(temp);
+                      }
+                    },
+                  );
           }),
         );
       });
@@ -420,7 +420,7 @@ class EditableState extends State<Editable> {
         child: SingleChildScrollView(
           scrollDirection: Axis.horizontal,
           child:
-          Column(crossAxisAlignment: widget.createButtonAlign, children: [
+              Column(crossAxisAlignment: widget.createButtonAlign, children: [
             //Table Header
             createButton(),
             Container(

--- a/lib/widgets/table_body.dart
+++ b/lib/widgets/table_body.dart
@@ -17,6 +17,7 @@ class RowBuilder extends StatefulWidget {
     @required this.tdPaddingTop,
     @required this.tdPaddingBottom,
     @required this.tdPaddingRight,
+    @required this.tdEditableMaxLines,
     @required this.onSubmitted,
     @required this.onChanged,
     @required this.widthRatio,
@@ -45,6 +46,7 @@ class RowBuilder extends StatefulWidget {
   final double tdPaddingTop;
   final double tdPaddingBottom;
   final double tdPaddingRight;
+  final int tdEditableMaxLines;
   final Color stripeColor1;
   final Color stripeColor2;
   final bool zebraStripe;
@@ -80,6 +82,7 @@ class _RowBuilderState extends State<RowBuilder> {
                 onFieldSubmitted: widget.onSubmitted,
                 onChanged: widget.onChanged,
                 textAlignVertical: TextAlignVertical.center,
+                maxLines: widget.tdEditableMaxLines,
                 decoration: InputDecoration(
                   filled: widget.zebraStripe,
                   fillColor: widget.index % 2 == 1.0

--- a/lib/widgets/table_body.dart
+++ b/lib/widgets/table_body.dart
@@ -67,6 +67,9 @@ class _RowBuilderState extends State<RowBuilder> {
         height: widget._trHeight < 40 ? 40 : widget._trHeight,
         width: width * widget.widthRatio,
         decoration: BoxDecoration(
+            color: !widget.zebraStripe ? null : (widget.index % 2 == 1.0
+                ? widget.stripeColor2
+                : widget.stripeColor1),
             border: Border.all(
                 color: widget._borderColor, width: widget._borderWidth)),
         child: widget.isEditable
@@ -100,9 +103,9 @@ class _RowBuilderState extends State<RowBuilder> {
                   // bottom: widget.tdPaddingBottom,
                 ),
                 decoration: BoxDecoration(
-                  color: widget.index % 2 == 1.0
+                  color: !widget.zebraStripe ? null : (widget.index % 2 == 1.0
                       ? widget.stripeColor2
-                      : widget.stripeColor1,
+                      : widget.stripeColor1),
                 ),
                 child: Text(
                   widget.cellData.toString(),

--- a/lib/widgets/table_body.dart
+++ b/lib/widgets/table_body.dart
@@ -112,9 +112,9 @@ class _RowBuilderState extends State<RowBuilder> {
                 ),
                 child: Text(
                   widget.cellData.toString(),
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                      // fontSize: Theme.of(context).textTheme.bodyText1.fontSize), // returns 14?
+                  textAlign: widget.tdAlignment ?? TextAlign.center,
+                  style: widget.tdStyle ?? TextStyle(
+                    // fontSize: Theme.of(context).textTheme.bodyText1.fontSize), // returns 14?
                       fontSize: 16),
                 ),
               ),

--- a/lib/widgets/table_header.dart
+++ b/lib/widgets/table_header.dart
@@ -4,17 +4,17 @@ class THeader extends StatelessWidget {
   ///Builds elements for the table headers
   const THeader(
       {Key key,
-        @required this.thPaddingLeft,
-        @required this.thPaddingTop,
-        @required this.thPaddingBottom,
-        @required this.thPaddingRight,
-        @required List headers,
-        @required this.thAlignment,
-        @required this.thStyle,
-        @required FontWeight thWeight,
-        @required double thSize,
-        @required double widthRatio,
-        @required int index})
+      @required this.thPaddingLeft,
+      @required this.thPaddingTop,
+      @required this.thPaddingBottom,
+      @required this.thPaddingRight,
+      @required List headers,
+      @required this.thAlignment,
+      @required this.thStyle,
+      @required FontWeight thWeight,
+      @required double thSize,
+      @required double widthRatio,
+      @required int index})
       : _headers = headers,
         _thWeight = thWeight,
         _thSize = thSize,

--- a/lib/widgets/table_header.dart
+++ b/lib/widgets/table_header.dart
@@ -39,7 +39,6 @@ class THeader extends StatelessWidget {
     return Flexible(
       fit: FlexFit.loose,
       child: Container(
-        alignment: Alignment(0.5,2.0),
         width: width * _widthRatio,
         child: Padding(
           padding: EdgeInsets.only(

--- a/lib/widgets/table_header.dart
+++ b/lib/widgets/table_header.dart
@@ -4,15 +4,17 @@ class THeader extends StatelessWidget {
   ///Builds elements for the table headers
   const THeader(
       {Key key,
-      @required this.thPaddingLeft,
-      @required this.thPaddingTop,
-      @required this.thPaddingBottom,
-      @required this.thPaddingRight,
-      @required List headers,
-      @required FontWeight thWeight,
-      @required double thSize,
-      @required double widthRatio,
-      @required int index})
+        @required this.thPaddingLeft,
+        @required this.thPaddingTop,
+        @required this.thPaddingBottom,
+        @required this.thPaddingRight,
+        @required List headers,
+        @required this.thAlignment,
+        @required this.thStyle,
+        @required FontWeight thWeight,
+        @required double thSize,
+        @required double widthRatio,
+        @required int index})
       : _headers = headers,
         _thWeight = thWeight,
         _thSize = thSize,
@@ -25,6 +27,8 @@ class THeader extends StatelessWidget {
   final double thPaddingBottom;
   final double thPaddingRight;
   final List _headers;
+  final TextAlign thAlignment;
+  final TextStyle thStyle;
   final FontWeight _thWeight;
   final double _thSize;
   final int _index;
@@ -35,6 +39,7 @@ class THeader extends StatelessWidget {
     return Flexible(
       fit: FlexFit.loose,
       child: Container(
+        alignment: Alignment(0.5,2.0),
         width: width * _widthRatio,
         child: Padding(
           padding: EdgeInsets.only(
@@ -46,7 +51,8 @@ class THeader extends StatelessWidget {
             _headers != null || _headers.isNotEmpty
                 ? _headers[_index]['title']
                 : '',
-            style: TextStyle(fontWeight: _thWeight, fontSize: _thSize),
+            style: thStyle ?? TextStyle(fontWeight: _thWeight, fontSize: _thSize),
+            textAlign: thAlignment ?? TextAlign.start,
           ),
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: editable
-description: ⚡️A highly customizable, editable data table (spreadsheet) package for Flutter projects.
+description: A highly customizable, editable data table (spreadsheet) package for Flutter projects.
 version: 1.1.3
 homepage: https://github.com/godilite/editable
 


### PR DESCRIPTION
I have fixed a couple existing bugs with styling (zebra stripes did not cover cell on editable data rows when non-editable rows wrapped, zebra stripes were still visible on non-editable rows when stripes turned off, maybe others, see code/comments)

I have also added support for completely controlling the style and alignment of the table headers. 

I also made changes so that when styling/alignment is specified for table data then it is ALSO used by the non editable columns.

Added support for specifying max lines for editable data cells so that they can wrap and have all data visible.

Added some small changes to example to illustrate some of these capabilities/fixes.

All changes were made to ensure that all existing behavior stays the same when the features are not used.  (The data styling is now used for NON-editable table data however, but that seems like a bug when it wasn't used)

Thanks for the widget!
