### PR TITLE
Be able to set Widgets in the Cols

### DIFF
--- a/lib/widgets/table_header.dart
+++ b/lib/widgets/table_header.dart
@@ -49,7 +49,7 @@ class THeader extends StatelessWidget {
           child: Text(
             _headers != null || _headers!.isNotEmpty
                 ? _headers![_index]['title']
-                : '',
+                : Container(),
             style:
                 thStyle ?? TextStyle(fontWeight: _thWeight, fontSize: _thSize),
             textAlign: thAlignment ?? TextAlign.start,


### PR DESCRIPTION
Make it possible to set Widgets in the Cols

```
List cols = [
    {
      "title": Text("Name"),
      'widthFactor': 0.3,
      'key': 'name',
      'editable': true
    },];
```